### PR TITLE
Fix refuel unable to locate Tritium slot since ED 4.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The release comes bundled with everything you need to use both the admin panel a
 * Dock with your carrier.
 * Make sure your cursor is over the "Carrier Services" option, and that your internal panel (right) is on the home tab.
 * Open the traversal system from the admin interface. Fill in the options:
-  * Tritium slot: how many up-presses it takes to get to Tritium in the cargo transfer menu. IMPORTANT - take out a unit of Tritium first, as this changes where it's positioned.
+  * Tritium slot: How many down-presses it takes to get to Tritium from the first item in the cargo transfer menu.
   * Webhook URL: The URL to send Discord updates to.
   * Journal Dir: The directory of your Elite Dangerous journal files (will autofill when settings are saved).
   * Route: Put each system on a new line. Alternatively, import from a plain text list of systems, or a CSV from Spansh's FC plotter.

--- a/TraversalSystem/main.py
+++ b/TraversalSystem/main.py
@@ -39,7 +39,7 @@ user32 = ctypes.windll.user32
 ctypes.windll.shcore.SetProcessDpiAwareness(2)
 
 # ----Options----
-# How many up presses to reach tritium in carrier hold:
+# How many down presses to reach tritium from first item in carrier hold:
 global tritium_slot
 tritium_slot = 0
 # Time to refill trit
@@ -210,7 +210,7 @@ def restock_tritium():
         if step == "open_cargo_transfer":
             # at the end of the cargo transfer step, we need to select the correct trit slot based on user input
             for _ in range(tritium_slot):
-                pydirectinput.press('w')
+                pydirectinput.press('s')
                 time.sleep(slight_random_time(0.1))
 
     print("Refuel process completed.")

--- a/TraversalSystem/sequences/open_cargo_transfer.txt
+++ b/TraversalSystem/sequences/open_cargo_transfer.txt
@@ -7,3 +7,4 @@ d
 w
 d
 space
+w:10


### PR DESCRIPTION
4.1.2 changes the cargo transfer operation logic, "up" press no longer select the last item now, instead it moves selection to the 8th slot(last slot of the initial view, if Tritium slot beyond 8th slot, it will makes the previous process unable to locate the Tritium slot.

New operation method:

Long-press "UP" to located the selection to the first item in cargo transfer menu, then go down to Tritium slot.

In the method the Tritium slot will ne the down presses from the first item to Tritium slot.